### PR TITLE
Make default client name

### DIFF
--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -52,7 +52,7 @@ defmodule Rivulet.Application do
     kafka_hosts = kafka_brokers()
 
     if System.get_env("MIX_ENV") != "test" do
-      client_name = Application.get_env(:rivulet, :publish_client_name)
+      client_name = Application.get_env(:rivulet, :publish_client_name, :"rivulet_brod_client-#{System.get_env("HOSTNAME")}")
       :ok = :brod.start_client(kafka_hosts, client_name, _client_config=[auto_start_producers: true])
     else
       Logger.info("Test Environment detected - not starting :brod")


### PR DESCRIPTION
We need to set a default name for the publish client name.