### PR TITLE
Try default max batch size

### DIFF
--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -29,7 +29,7 @@ defmodule Rivulet.Application do
     if System.get_env("MIX_ENV") != "test" do
       client_name = Rivulet.client_name
 
-      default_producer_config = [max_batch_size: 100]
+      default_producer_config = []
 
       :ok =
         :brod.start_client(kafka_hosts, client_name, _client_config=[


### PR DESCRIPTION
max_batch_size refers to producer batching, not consumer batching. 100 means bytes, not messages. Let's just use the default. This made a huge improvement on throughput in my testing.