### PR TITLE
Potentially Update :brod Producer Configuration

### DIFF
--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -29,7 +29,12 @@ defmodule Rivulet.Application do
     if System.get_env("MIX_ENV") != "test" do
       client_name = Rivulet.client_name
 
-      default_producer_config = []
+      default_producer_config = [
+        required_acks: 1, # by default this is -1, meaning "all", within :brod (options are 0, 1, -1)
+        # ack_timeout: 10000, # the max number of time the producer should wait to receive a response that message was received by all required insync replicas before timing out. default is: 10000ms
+        max_retries: 30, # by default this is 3 within :brod, -1 means "retry indefinitely"
+        retry_backoff_ms: 1000 # by default this is 500ms within :brod
+      ]
 
       :ok =
         :brod.start_client(kafka_hosts, client_name, _client_config=[


### PR DESCRIPTION
See all potential configuration variables here:
http://kafka.apache.org/documentation.html#producerconfigs

See the names that brod allows us to pass into the config here: https://github.com/klarna/brod/blob/20474e9c86b6f645e04514c265f6e8de3fe8e010/src/brod_producer.erl

Example: The Kafka Producer API looks for a `retries` property, but `:brod` calls it `max_retries`.