### PR TITLE
fix aliases

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,8 @@ defmodule Rivulet.Mixfile do
 
   defp aliases do
     [
-      "compile": ["compile --warnings-as-errors"],
-      "test": ["test --no-start"]
+      compile: ["compile --warnings-as-errors"],
+      test: ["test --no-start"]
     ]
   end
 


### PR DESCRIPTION
Updating to elixir 1.8 in CG and I kept getting the following compiler warnings for this dep..
```
warning: found quoted keyword "compile" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of Unicode letters, numbers, underscore, and @ do not require quotes
  /Users/juniormatelau/projects/connector_gate/deps/rivulet/mix.exs:29

warning: found quoted keyword "test" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of Unicode letters, numbers, underscore, and @ do not require quotes
  /Users/juniormatelau/projects/connector_gate/deps/rivulet/mix.exs:30
```