### PR TITLE
update producer config to make it overrideable

### DIFF
--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -58,12 +58,8 @@ defmodule Rivulet.Application do
     ]
 
     Enum.reduce(Keyword.keys(custom_config), default_producer_config, fn k, acc ->
-      if Keyword.has_key?(acc, k) do
-        new_value = Keyword.get(custom_config, k)
-        Keyword.put(acc, k, new_value)
-      else
-        acc
-      end
+      new_value = Keyword.get(custom_config, k)
+      Keyword.put(acc, k, new_value)
     end)
   end
 

--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -65,9 +65,6 @@ defmodule Rivulet.Application do
         acc
       end
     end)
-    # Enum.reduce(Keyword.keys(custom_config), default_producer_config, fn x, acc ->
-    #   Keyword.replace!(acc, x, Keyword.get(custom_config, x))
-    # end)
   end
 
   def kafka_brokers do

--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -26,6 +26,11 @@ defmodule Rivulet.Application do
 
     kafka_hosts = kafka_brokers()
 
+    producer_config =
+      :rivulet
+      |> Application.get_all_env()
+      |> kafka_producer_config()
+
     if System.get_env("MIX_ENV") != "test" do
       client_name = Rivulet.client_name
 
@@ -33,22 +38,36 @@ defmodule Rivulet.Application do
         raise "`config :rivulet, client_name: client_name` must be an atom, not a string"
       end
 
-      default_producer_config = [
-        required_acks: 1, # by default this is -1, meaning "all", within :brod (options are 0, 1, -1)
-        # ack_timeout: 10000, # the max number of time the producer should wait to receive a response that message was received by all required insync replicas before timing out. default is: 10000ms
-        max_retries: 30, # by default this is 3 within :brod, -1 means "retry indefinitely"
-        retry_backoff_ms: 1000 # by default this is 500ms within :brod
-      ]
-
       :ok =
         :brod.start_client(kafka_hosts, client_name, _client_config=[
           auto_start_producers: true,
           allow_topic_auto_creation: false,
-          default_producer_config: default_producer_config
+          default_producer_config: producer_config
         ])
     else
       Logger.info("Test Environment detected - not starting :brod")
     end
+  end
+
+  def kafka_producer_config(custom_config) do
+    default_producer_config = [
+      required_acks: 1, # by default this is -1, meaning "all", within :brod (options are 0, 1, -1)
+      ack_timeout: 10000, # the max number of time the producer should wait to receive a response that message was received by all required insync replicas before timing out. default is: 10000ms
+      max_retries: 30, # by default this is 3 within :brod, -1 means "retry indefinitely"
+      retry_backoff_ms: 1000 # by default this is 500ms within :brod
+    ]
+
+    Enum.reduce(Keyword.keys(custom_config), default_producer_config, fn k, acc ->
+      if Keyword.has_key?(acc, k) do
+        new_value = Keyword.get(custom_config, k)
+        Keyword.put(acc, k, new_value)
+      else
+        acc
+      end
+    end)
+    # Enum.reduce(Keyword.keys(custom_config), default_producer_config, fn x, acc ->
+    #   Keyword.replace!(acc, x, Keyword.get(custom_config, x))
+    # end)
   end
 
   def kafka_brokers do

--- a/test/application_test.exs
+++ b/test/application_test.exs
@@ -1,0 +1,39 @@
+defmodule Rivulet.Application.Test do
+  use ExUnit.Case
+
+  alias Rivulet.Application
+
+  describe "kafka_producer_config/1" do
+    test "overrides defaults if custom configuration is provided" do
+      input = [
+        required_acks: 0
+      ]
+
+      expected = [
+        required_acks: 0,
+        ack_timeout: 10000,
+        max_retries: 30,
+        retry_backoff_ms: 1000
+      ]
+
+      result = Application.kafka_producer_config(input)
+
+      assert result == expected
+    end
+
+    test "falls back to defaults if custom configuration is not provided" do
+      input = []
+
+      expected = [
+        required_acks: 1,
+        ack_timeout: 10000,
+        max_retries: 30,
+        retry_backoff_ms: 1000
+      ]
+
+      result = Application.kafka_producer_config(input)
+
+      assert result == expected
+    end
+  end
+end


### PR DESCRIPTION
Jake wants fire and forget ability for his producer into Kafka. This allows him to do that.
<img width="911" alt="screen shot 2019-02-05 at 3 28 07 pm" src="https://user-images.githubusercontent.com/7155709/52599096-e5bb6d00-2e14-11e9-874f-eb87014570e0.png">
