### PR TITLE
update for when producer config is not defined

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -4,10 +4,7 @@ config :rivulet,
   avro_schema_registry_uri: %URI{scheme: "http", host: "rivulet_schema-registry_1", port: 8081},
   kafka_brokers: [rivulet_kafka_1: 9092],
   client_name: :"rivulet-client-#{System.get_env("HOSTNAME")}",
-  json_handler: Rivulet.JSON.JiffyHandler,
-  producer: [
-    required_acks: 0
-  ]
+  json_handler: Rivulet.JSON.JiffyHandler
 
 # Configure elastix
 config :elastix,

--- a/config/config.exs
+++ b/config/config.exs
@@ -4,7 +4,10 @@ config :rivulet,
   avro_schema_registry_uri: %URI{scheme: "http", host: "rivulet_schema-registry_1", port: 8081},
   kafka_brokers: [rivulet_kafka_1: 9092],
   client_name: :"rivulet-client-#{System.get_env("HOSTNAME")}",
-  json_handler: Rivulet.JSON.JiffyHandler
+  json_handler: Rivulet.JSON.JiffyHandler,
+  producer: [
+    required_acks: 0
+  ]
 
 # Configure elastix
 config :elastix,

--- a/lib/rivulet/application.ex
+++ b/lib/rivulet/application.ex
@@ -28,7 +28,7 @@ defmodule Rivulet.Application do
 
     producer_config =
       :rivulet
-      |> Application.get_all_env()
+      |> Application.get_env(:producer)
       |> kafka_producer_config()
 
     if System.get_env("MIX_ENV") != "test" do
@@ -47,6 +47,15 @@ defmodule Rivulet.Application do
     else
       Logger.info("Test Environment detected - not starting :brod")
     end
+  end
+
+  def kafka_producer_config(nil) do
+    [
+      required_acks: 1, # by default this is -1, meaning "all", within :brod (options are 0, 1, -1)
+      ack_timeout: 10000, # the max number of time the producer should wait to receive a response that message was received by all required insync replicas before timing out. default is: 10000ms
+      max_retries: 30, # by default this is 3 within :brod, -1 means "retry indefinitely"
+      retry_backoff_ms: 1000 # by default this is 500ms within :brod
+    ]
   end
 
   def kafka_producer_config(custom_config) do

--- a/test/application_test.exs
+++ b/test/application_test.exs
@@ -22,7 +22,7 @@ defmodule Rivulet.Application.Test do
     end
 
     test "falls back to defaults if custom configuration is not provided" do
-      input = []
+      input = nil
 
       expected = [
         required_acks: 1,


### PR DESCRIPTION
So this makes it so they can define a `producer` keyword list as part of their `rivulet` config and if it does not exist, we just fall back to defaults.

Example:

```
config :rivulet,
  avro_schema_registry_uri: %URI{scheme: "http", host: "rivulet_schema-registry_1", port: 8081},
  kafka_brokers: [rivulet_kafka_1: 9092],
  client_name: :"rivulet-client-#{System.get_env("HOSTNAME")}",
  json_handler: Rivulet.JSON.JiffyHandler,
  producer: [
    required_acks: 0
  ]

```